### PR TITLE
fix: Lock update_db function

### DIFF
--- a/backend/chatsky_ui/api/api_v1/endpoints/flows.py
+++ b/backend/chatsky_ui/api/api_v1/endpoints/flows.py
@@ -37,7 +37,7 @@ async def flows_get(
                 detail="Failed to checkout the latest commit",
             ) from e
 
-    omega_flows = await read_conf(settings.frontend_flows_path)
+    omega_flows = await read_conf(settings.frontend_flows_path, settings.frontend_flows_path_lock)
     dict_flows = OmegaConf.to_container(omega_flows, resolve=True)
     return {"status": "ok", "data": dict_flows}  # type: ignore
 
@@ -51,7 +51,7 @@ async def flows_post(
     tags = sorted(build_manager.graph_repo_manager.repo.tags, key=lambda t: t.commit.committed_datetime)
     build_manager.graph_repo_manager.checkout_tag(tags[-1], settings.frontend_flows_path.name)
 
-    await write_conf(flows, settings.frontend_flows_path)
+    await write_conf(flows, settings.frontend_flows_path, settings.frontend_flows_path_lock)
     build_manager.graph_repo_manager.commit_changes("Save frontend flows")
 
     return {"status": "ok"}

--- a/backend/chatsky_ui/core/config.py
+++ b/backend/chatsky_ui/core/config.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import os
 from pathlib import Path
@@ -29,6 +30,10 @@ class Settings:
         self.start_page = self.static_files / "index.html"
         self.package_dir = self.config_file_path.parents[2]
         self.temp_conf = self.config_file_path.with_name("temp_conf.yaml")
+
+        self.builds_path_lock = asyncio.Lock()
+        self.runs_path_lock = asyncio.Lock()
+        self.frontend_flows_path_lock = asyncio.Lock()
 
         self.set_config(
             host=os.getenv("HOST", "0.0.0.0"),

--- a/backend/chatsky_ui/db/base.py
+++ b/backend/chatsky_ui/db/base.py
@@ -7,20 +7,18 @@ from omegaconf import OmegaConf
 from omegaconf.dictconfig import DictConfig
 from omegaconf.listconfig import ListConfig
 
-file_lock = Lock()
 
-
-async def read_conf(path: Path) -> Union[DictConfig, ListConfig]:
-    async with file_lock:
+async def read_conf(path: Path, lock) -> Union[DictConfig, ListConfig]:
+    async with lock:
         async with aiofiles.open(path, "r", encoding="UTF-8") as file:
             data = await file.read()
     omega_data = OmegaConf.create(data)  # read from a YAML string
     return omega_data
 
 
-async def write_conf(data: Union[DictConfig, ListConfig, dict, list], path: Path) -> None:
+async def write_conf(data: Union[DictConfig, ListConfig, dict, list], path: Path, lock) -> None:
     yaml_conf = OmegaConf.to_yaml(data)
-    async with file_lock:
+    async with lock:
         async with aiofiles.open(path, "w", encoding="UTF-8") as file:  # TODO: change to "a" for append
             await file.write(yaml_conf)
 

--- a/backend/chatsky_ui/db/base.py
+++ b/backend/chatsky_ui/db/base.py
@@ -1,4 +1,3 @@
-from asyncio import Lock
 from pathlib import Path
 from typing import List, Union
 

--- a/backend/chatsky_ui/schemas/front_graph_components/info_holders/condition.py
+++ b/backend/chatsky_ui/schemas/front_graph_components/info_holders/condition.py
@@ -63,7 +63,7 @@ class RegexpCondition(Regexp):
 
     @model_validator(mode="after")
     def validate_flags(self) -> "RegexpCondition":
-        allowed_keys = {"ignoreCase"}
+        allowed_keys = {"caseSensitive"}
         invalid_keys = set(self.flags) - allowed_keys
         if invalid_keys:
             raise ValueError(f"Invalid key(s) {invalid_keys} in flags. Allowed keys are {allowed_keys}")

--- a/backend/chatsky_ui/services/json_converter/logic_component_converter/chatsky_condition_converter.py
+++ b/backend/chatsky_ui/services/json_converter/logic_component_converter/chatsky_condition_converter.py
@@ -77,7 +77,7 @@ class RegexpConditionConverter(BaseChatskyConditionConverter):
 
     def _map_flags(self, flags: dict) -> int:
         flag_value = 0
-        if flags.get("ignoreCase", False):
+        if not flags.get("caseSensitive", False):
             flag_value |= re.IGNORECASE.value
         return flag_value
 

--- a/backend/chatsky_ui/services/json_converter/node_converter.py
+++ b/backend/chatsky_ui/services/json_converter/node_converter.py
@@ -24,10 +24,12 @@ class NodeConverter(BaseConverter):
 
 class InfoNodeConverter(NodeConverter):
     MAP_TR2CHATSKY = {
-        "start": "dst.Start",
-        "fallback": "dst.Fallback",
-        "previous": "dst.Previous",
-        "repeat": "dst.Current",
+        "start": {"chatsky.destinations.Start": {}},
+        "fallback": {"chatsky.destinations.Fallback": {}},
+        "previous": {"chatsky.destinations.Previous": {}},
+        "current": {"chatsky.destinations.Current": {}},
+        "forward": {"chatsky.destinations.Forward": {}},
+        "backward": {"chatsky.destinations.Backward": {}},
     }
 
     def __init__(self, node: dict):
@@ -50,14 +52,15 @@ class InfoNodeConverter(NodeConverter):
             RESPONSE: self.RESPONSE_CONVERTER[self.node.response["type"]](self.node.response)(),
             TRANSITIONS: [
                 {
-                    "dst": condition["dst"]
+                    "dst": condition.get("dst", [])
                     if condition["data"]["transition_type"] == "manual"
-                    else self.MAP_TR2CHATSKY[condition["data"]["transition_type"]],
+                    else self.MAP_TR2CHATSKY.get(
+                        condition["data"]["transition_type"], self.MAP_TR2CHATSKY["fallback"]
+                    ),
                     "priority": condition["data"]["priority"],
                     "cnd": converter(slots_conf=self.slots_conf),
                 }
                 for condition, converter in zip(self.node.conditions, condition_converters)
-                if "dst" in condition
             ],
             PRE_TRANSITION: {
                 key: value

--- a/backend/chatsky_ui/services/json_converter/node_converter.py
+++ b/backend/chatsky_ui/services/json_converter/node_converter.py
@@ -54,9 +54,7 @@ class InfoNodeConverter(NodeConverter):
                 {
                     "dst": condition.get("dst", [])
                     if condition["data"]["transition_type"] == "manual"
-                    else self.MAP_TR2CHATSKY.get(
-                        condition["data"]["transition_type"], self.MAP_TR2CHATSKY["fallback"]
-                    ),
+                    else self.MAP_TR2CHATSKY.get(condition["data"]["transition_type"], self.MAP_TR2CHATSKY["fallback"]),
                     "priority": condition["data"]["priority"],
                     "cnd": converter(slots_conf=self.slots_conf),
                 }

--- a/backend/chatsky_ui/services/process_manager.py
+++ b/backend/chatsky_ui/services/process_manager.py
@@ -30,6 +30,7 @@ from chatsky_ui.utils.repo_manager import RepoManager
 
 class ProcessManager(ABC):
     """Base for build and run process managers."""
+
     _db_lock = asyncio.Lock()
 
     def __init__(self):

--- a/backend/chatsky_ui/services/process_manager.py
+++ b/backend/chatsky_ui/services/process_manager.py
@@ -30,6 +30,7 @@ from chatsky_ui.utils.repo_manager import RepoManager
 
 class ProcessManager(ABC):
     """Base for build and run process managers."""
+    _db_lock = asyncio.Lock()
 
     def __init__(self):
         self.processes: Dict[int, Union[BuildProcess, RunProcess]] = {}
@@ -120,6 +121,7 @@ class ProcessManager(ABC):
                 Status.FAILED,
                 Status.FAILED_WITH_UNEXPECTED_CODE,
             ]:
+                await self.update_db_info()
                 break
             await asyncio.sleep(2)  # TODO: ?sleep time shouldn't be constant
 
@@ -127,22 +129,22 @@ class ProcessManager(ABC):
         """Checks the status of the process with the given id by calling the `check_status` method of the process."""
         return await self.processes[id_].check_status()
 
-    async def get_process_info(self, id_: int, path: Path) -> Optional[Dict[str, Any]]:
+    async def get_process_info(self, id_: int, path: Path, path_lock) -> Optional[Dict[str, Any]]:
         """Returns metadata of a specific process identified by its unique ID."""
-        db_conf = await read_conf(path)
+        db_conf = await read_conf(path, path_lock)
         conf_dict = OmegaConf.to_container(db_conf, resolve=True)
         return next((db_process for db_process in conf_dict if db_process["id"] == id_), None)  # type: ignore
 
-    async def get_full_info(self, offset: int, limit: int, path: Path) -> List[Dict[str, Any]]:
+    async def get_full_info(self, offset: int, limit: int, path: Path, path_lock) -> List[Dict[str, Any]]:
         """Returns metadata of ``limit`` number of processes, starting from the ``offset``th process."""
 
-        db_conf = await read_conf(path)
+        db_conf = await read_conf(path, path_lock)
         conf_dict = OmegaConf.to_container(db_conf, resolve=True)
         return conf_dict[offset : offset + limit]  # type: ignore
 
-    async def fetch_process_logs(self, id_: int, offset: int, limit: int, path: Path) -> Optional[List[str]]:
+    async def fetch_process_logs(self, id_: int, offset: int, limit: int, path: Path, path_lock) -> Optional[List[str]]:
         """Returns the logs of one process according to its id. If the process is not found, returns None."""
-        process_info = await self.get_process_info(id_, path)
+        process_info = await self.get_process_info(id_, path, path_lock)
         if process_info is None:
             self.logger.error("Id '%s' not found", id_)
             return None  # TODO: raise error and handle it!
@@ -200,7 +202,7 @@ class RunManager(ProcessManager):
             return max([run["id"] for run in await self.get_full_info(0, 10000)]) + 1
 
         async def _get_build_info(build_id):
-            build_info = await self.get_process_info(build_id, settings.builds_path) or {}
+            build_info = await self.get_process_info(build_id, settings.builds_path, settings.builds_path_lock) or {}
             if not build_info:
                 raise ValueError(f"Build id '{build_id}' not found in the database")
             port = build_info.get("port")
@@ -256,42 +258,43 @@ class RunManager(ProcessManager):
 
     async def get_run_info(self, id_: int) -> Optional[Dict[str, Any]]:
         """Returns metadata of  a specific run process identified by its unique ID."""
-        return await super().get_process_info(id_, settings.runs_path)
+        return await super().get_process_info(id_, settings.runs_path, settings.runs_path_lock)
 
     async def get_full_info(self, offset: int, limit: int, path: Path = None) -> List[Dict[str, Any]]:
         """Returns metadata of ``limit`` number of run processes, starting from the ``offset``th process."""
-        path = path or settings.runs_path
-        return await super().get_full_info(offset, limit, path)
+        path = settings.runs_path
+        return await super().get_full_info(offset, limit, path, settings.runs_path_lock)
 
     async def fetch_run_logs(self, run_id: int, offset: int, limit: int) -> Optional[List[str]]:
         """Returns the logs of one run according to its id.
 
         Number of loglines returned is based on `offset` as the start line and limited by `limit` lines.
         """
-        return await self.fetch_process_logs(run_id, offset, limit, settings.runs_path)
+        return await self.fetch_process_logs(run_id, offset, limit, settings.runs_path, settings.runs_path_lock)
 
     def get_port(self, run_id: int) -> Optional[int]:
         return self.processes[run_id].port
 
     async def update_db_info(self) -> None:
         # save current run info into runs_path
-        self.logger.debug("Updating db run info")
-        runs_conf = await read_conf(settings.runs_path)
-        builds_conf = await read_conf(settings.builds_path)
-        for process in self.processes.values():
-            run_params = (
-                await process.get_full_info()
-            )  # TODO: Try to use the process object attributes instead of having it as dict using get_full_info
-            runs_conf = RunManager.add_new_conf(runs_conf, run_params)  # type: ignore
+        async with ProcessManager._db_lock:
+            self.logger.debug("Updating db run info")
+            runs_conf = await read_conf(settings.runs_path, settings.runs_path_lock)
+            builds_conf = await read_conf(settings.builds_path, settings.builds_path_lock)
+            for process in self.processes.values():
+                run_params = (
+                    await process.get_full_info()
+                )  # TODO: Try to use the process object attributes instead of having it as dict using get_full_info
+                runs_conf = RunManager.add_new_conf(runs_conf, run_params)  # type: ignore
 
-            # save current run id into the correspoinding build in builds_path
-            for build in builds_conf:
-                if build.id == run_params["build_id"]:  # type: ignore
-                    if run_params["id"] not in build.run_ids:  # type: ignore
-                        build.run_ids.append(run_params["id"])  # type: ignore
-                        break
-        await write_conf(runs_conf, settings.runs_path)
-        await write_conf(builds_conf, settings.builds_path)
+                # save current run id into the correspoinding build in builds_path
+                for build in builds_conf:
+                    if build.id == run_params["build_id"]:  # type: ignore
+                        if run_params["id"] not in build.run_ids:  # type: ignore
+                            build.run_ids.append(run_params["id"])  # type: ignore
+                            break
+            await write_conf(runs_conf, settings.runs_path, settings.runs_path_lock)
+            await write_conf(builds_conf, settings.builds_path, settings.builds_path_lock)
 
 
 class BuildManager(ProcessManager):
@@ -380,25 +383,27 @@ class BuildManager(ProcessManager):
             ]:
                 self.bot_repo_manager.commit_with_tag(process.id)
                 self.graph_repo_manager.commit_with_tag(process.id)
+                await self.update_db_info()
                 break
 
     async def get_full_info(self, offset: int, limit: int, path: Path = None) -> List[Dict[str, Any]]:
         """Returns metadata of ``limit`` number of processes, starting from the ``offset`` process."""
-        path = path or settings.builds_path
-        return await super().get_full_info(offset, limit, path)
+        path = settings.builds_path
+        return await super().get_full_info(offset, limit, path, settings.builds_path_lock)
 
     async def fetch_build_logs(self, build_id: int, offset: int, limit: int) -> Optional[List[str]]:
         """Returns the logs of one build according to its id.
 
         Number of loglines returned is based on `offset` as the start line and limited by `limit` lines.
         """
-        return await self.fetch_process_logs(build_id, offset, limit, settings.builds_path)
+        return await self.fetch_process_logs(build_id, offset, limit, settings.builds_path, settings.builds_path_lock)
 
     async def update_db_info(self) -> None:
         """Saves current build info into builds_path"""
-        builds_conf = await read_conf(settings.builds_path)
-        for process in self.processes.values():
-            build_params = await process.get_full_info()
-            builds_conf = BuildManager.add_new_conf(builds_conf, build_params)  # type: ignore
+        async with ProcessManager._db_lock:
+            builds_conf = await read_conf(settings.builds_path, settings.builds_path_lock)
+            for process in self.processes.values():
+                build_params = await process.get_full_info()
+                builds_conf = BuildManager.add_new_conf(builds_conf, build_params)  # type: ignore
 
-        await write_conf(builds_conf, settings.builds_path)
+            await write_conf(builds_conf, settings.builds_path, settings.builds_path_lock)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "chatsky-ui"
-version = "0.5.0"
+version = "0.5.1"
 description = "Chatsky-UI is GUI for Chatsky Framework, that is a free and open-source software stack for creating chatbots, released under the terms of Apache License 2.0."
 license = "Apache-2.0"
 authors = [

--- a/frontend/src/modals/ConditionModal/components/BasicCondition.tsx
+++ b/frontend/src/modals/ConditionModal/components/BasicCondition.tsx
@@ -9,7 +9,7 @@ import DeleteBasicConditionIcon from "@/icons/nodes/conditions/deleteBasicCondit
 
 interface IDefObject {
  text?: string
- flags?: { ignoreCase: boolean }
+ flags?: { caseSensitive: boolean }
  data?: IDefObject[] | IDefObject | {}
  id?: string
  pattern?: string
@@ -32,7 +32,7 @@ interface IState {
   key?: string
   disabled?: boolean
  }[]
- flags?: { ignoreCase: boolean }
+ flags?: { caseSensitive: boolean }
 }
 
 const genDefObject = (key: string): IDefObject => {
@@ -46,13 +46,13 @@ const genDefObject = (key: string): IDefObject => {
    return {
     structure: "includeText",
     text: "",
-    flags: { ignoreCase: false },
+    flags: { caseSensitive: false },
    }
   case "Regular expression":
    return {
     structure: "regExp",
     pattern: "",
-    flags: { ignoreCase: false },
+    flags: { caseSensitive: false },
    }
   case "Any of":
    return { structure: "anyOf", data: [] }
@@ -127,9 +127,9 @@ const handleValueChangeCheckbox = (
   state.structure === "not"
    ? setState({
       ...state,
-      data: { ...state.data, flags: { ignoreCase: value } },
+      data: { ...state.data, flags: { caseSensitive: value } },
      })
-   : setState({ ...state, flags: { ignoreCase: value } })
+   : setState({ ...state, flags: { caseSensitive: value } })
   return
  }
 
@@ -137,8 +137,8 @@ const handleValueChangeCheckbox = (
   (item: IDefObject) => {
    if (item.id === id) {
     return item.structure === "not"
-     ? { ...item, data: { ...item.data, flags: { ignoreCase: value } } }
-     : { ...item, flags: { ignoreCase: value } }
+     ? { ...item, data: { ...item.data, flags: { caseSensitive: value } } }
+     : { ...item, flags: { caseSensitive: value } }
    }
    return item
   }
@@ -236,7 +236,7 @@ const mapping: IMapping = {
      <Checkbox
       isDisabled={true}
       aria-label="Case sensitive"
-      isSelected={getValue(state, id ?? "").flags?.ignoreCase}
+      isSelected={getValue(state, id ?? "").flags?.caseSensitive}
       type="checkbox"
       onValueChange={(value) =>
        handleValueChangeCheckbox(setState, state, id, value)
@@ -264,7 +264,7 @@ const mapping: IMapping = {
     <div className="flex items-center gap-2 pl-[12px] pt-[12px]">
      <Checkbox
       aria-label="Case sensitive"
-      isSelected={getValue(state, id ?? "").flags?.ignoreCase}
+      isSelected={getValue(state, id ?? "").flags?.caseSensitive}
       onValueChange={(value) =>
        handleValueChangeCheckbox(setState, state, id, value)
       }


### PR DESCRIPTION
# Description

* Lock it in both managers.
* In Runmanager it's important cuz it accesses both builds&runs files when updating
* Fix automatic transitions
* Revert case sensitive for Regexp as it should be

# Checklist

- [x] Update ui version
- [x] I have performed a self-review of the changes

*List here tasks to complete in order to mark this PR as ready for review.*

# To Consider

- Add tests (if functionality is changed)
- Update API reference / tutorials / guides
- Update CONTRIBUTING.md (if devel workflow is changed)
- Update `.ignore` files, scripts (such as `lint`), distribution manifest (if files are added/deleted)
- Search for references to changed entities in the codebase