### PR TITLE
fix: added SIGTERM handling for Uvicorn reloads

### DIFF
--- a/backend/chatsky_ui/main.py
+++ b/backend/chatsky_ui/main.py
@@ -12,21 +12,15 @@ from chatsky_ui.api.deps import run_manager
 from chatsky_ui.core.config import settings
 
 
-def sigint_signal_handler(self, signum):
+def signal_handler(self, signum):
     """Gracefully shuts down Chatsky-UI in case of receiving Ctrl+C signal."""
-    global stop_background_task
-    print("Caught SIGINT termination signal, shutting down gracefully...")
     for process in run_manager.processes.values():
         process.to_be_terminated = True
-    settings.temp_conf.unlink(missing_ok=True)
-
-
-def sigterm_signal_handler(self, signum):
-    """Gracefully shuts down Chatsky-UI in case of Uvicorn reloading. (Uvicorn sends SIGTERM to end the app lifespan)"""
-    global stop_background_task
-    print("Caught SIGTERM termination signal, shutting down gracefully and restarting Chatsky-UI...")
-    for process in run_manager.processes.values():
-        process.to_be_terminated = True
+    if signum == signal.SIGINT:
+        print("Caught SIGINT termination signal, shutting down gracefully...")
+        settings.temp_conf.unlink(missing_ok=True)
+    elif signum == signal.SIGTERM:
+        print("Caught SIGTERM termination signal, shutting down gracefully and restarting Chatsky-UI...")
 
 
 @asynccontextmanager
@@ -34,13 +28,15 @@ async def lifespan(app: FastAPI):
     if settings.temp_conf.exists():
         settings.refresh_work_dir()
     if threading.current_thread() is threading.main_thread():
-        signal.signal(signal.SIGINT, sigint_signal_handler)
-        signal.signal(signal.SIGTERM, sigterm_signal_handler)
+        signal.signal(signal.SIGINT, signal_handler)
+        signal.signal(signal.SIGTERM, signal_handler)
     yield
+    
+    run_manager.set_logger()
     await run_manager.stop_all()
 
 
-app = FastAPI(title="DF Designer", version=__version__, lifespan=lifespan)
+app = FastAPI(title="Chatsky UI", version=__version__, lifespan=lifespan)
 
 
 app.add_middleware(

--- a/backend/chatsky_ui/main.py
+++ b/backend/chatsky_ui/main.py
@@ -12,9 +12,19 @@ from chatsky_ui.api.deps import run_manager
 from chatsky_ui.core.config import settings
 
 
-def signal_handler(self, signum):
+def sigint_signal_handler(self, signum):
+    """Gracefully shuts down Chatsky-UI in case of receiving Ctrl+C signal."""
     global stop_background_task
-    print("Caught termination signal, shutting down gracefully...")
+    print("Caught SIGINT termination signal, shutting down gracefully...")
+    for process in run_manager.processes.values():
+        process.to_be_terminated = True
+    settings.temp_conf.unlink(missing_ok=True)
+
+
+def sigterm_signal_handler(self, signum):
+    """Gracefully shuts down Chatsky-UI in case of Uvicorn reloading. (Uvicorn sends SIGTERM to end the app lifespan)"""
+    global stop_background_task
+    print("Caught SIGTERM termination signal, shutting down gracefully and restarting Chatsky-UI...")
     for process in run_manager.processes.values():
         process.to_be_terminated = True
 
@@ -24,10 +34,9 @@ async def lifespan(app: FastAPI):
     if settings.temp_conf.exists():
         settings.refresh_work_dir()
     if threading.current_thread() is threading.main_thread():
-        signal.signal(signal.SIGINT, signal_handler)
+        signal.signal(signal.SIGINT, sigint_signal_handler)
+        signal.signal(signal.SIGTERM, sigterm_signal_handler)
     yield
-
-    settings.temp_conf.unlink(missing_ok=True)
     await run_manager.stop_all()
 
 

--- a/backend/chatsky_ui/main.py
+++ b/backend/chatsky_ui/main.py
@@ -31,7 +31,7 @@ async def lifespan(app: FastAPI):
         signal.signal(signal.SIGINT, signal_handler)
         signal.signal(signal.SIGTERM, signal_handler)
     yield
-    
+
     run_manager.set_logger()
     await run_manager.stop_all()
 


### PR DESCRIPTION
# Description

- Added `SIGTERM` handling, so that `temp_conf.yaml` isn't deleted during Uvicorn reloads (Uvicorn sends `SIGTERM` to the app `lifespan, when it wants to reload the app). Instead, the temp config file is only deleted after receiving `SIGINT`, meaning the reload is now 'graceful'.
- Another related bug was Chatsky-UI processes not being terminated during a reload due to the app `lifespan` not handling `SIGTERM`, it's now fixed.

# Checklist

- [x] I tested locally that the relevant bugs are fixed
- [x] I have performed a self-review of the changes

# To Consider

- Add tests for signal handling
- Update CONTRIBUTING.md (if devel workflow is changed)