### PR TITLE
fix: unicode characters allowed in build.yaml (Chatsky pipeline file)

### DIFF
--- a/backend/chatsky_ui/services/json_converter/pipeline_converter.py
+++ b/backend/chatsky_ui/services/json_converter/pipeline_converter.py
@@ -40,7 +40,7 @@ class PipelineConverter(BaseConverter):
 
     def to_yaml(self, dir_path: Path):
         with open(f"{dir_path}/build.yaml", "w", encoding="UTF-8") as file:
-            yaml.dump(self.converted_pipeline, file, Dumper=Dumper, default_flow_style=False)
+            yaml.dump(self.converted_pipeline, file, Dumper=Dumper, default_flow_style=False, allow_unicode=True)
 
     def _convert(self):
         slots_converter = SlotsConverter(self.pipeline.flows)


### PR DESCRIPTION
# Description

Allowed unicode characters in Chatsky pipeline file (build.yaml). I didn't have to radically change the `json_converter` module, it was really just this one line with `yaml.dump` which was encoding unicode symbols as utf-8 for some reason, so `allow_unicode = True` fixed it just like that.
This is a one-liner Pull Request, I'm not sure this should be a PR and not just a commit straight to dev.

# Checklist

- [x] I have performed a self-review of the changes

# To Consider

- Check if `slots` with russian symbols work, they kinda didn't work on my machine (it still runs, but the response is not the expected one). This may be an unrelated bug, though, I remember having the same problem before.